### PR TITLE
Move main update code into separate function and loop forever

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ use unicorn_hat_hd::{UnicornHatHd, Rotate};
 mod settings;
 mod display;
 
+use std::thread;
+use std::time::Duration;
+
 use display::{MetricType, RGB};
 
 fn main() {
@@ -28,7 +31,15 @@ fn main() {
         Ok(s) => s,
         Err(e) => panic!("Could not read settings: {}", e),
     };
-    let token = settings.github_token;
+
+    loop {
+        update_display(&settings, &mut uhd);
+        thread::sleep(Duration::from_secs(600));
+    }
+}
+
+fn update_display(settings: &settings::Settings, mut uhd: &mut UnicornHatHd) {
+    let token = settings.github_token.clone();
 
     let mut core = Core::new().expect("reactor fail");
     let github = Github::new(
@@ -39,7 +50,7 @@ fn main() {
 
     let mut metrics = vec![];
 
-    for repo in settings.repositories {
+    for repo in &settings.repositories {
         let hubcap_repo = github.repo(repo.user.clone(), repo.name.clone());
         let mut open_issues = 0;
         let mut closed_issues = 0;


### PR DESCRIPTION
We now loop forever calling update_display with a 10 minute delay. This more easily lets us set this up as a service on the Raspberry PI, so it can automatically start on boot.

We'll still need to get rid of all the unwrap() calls so we don't blow up if any GitHub API calls fail, and the 10 minute delay shouldn't be hard-coded, but these are things that can be handled later.